### PR TITLE
Use https api endpoints from Ryanair API

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -18,9 +18,9 @@
     ENTER: 13
   })
   .constant('API', {
-    AIRPORTS: '/cors/http://ryanair-test.herokuapp.com/api/airports',
-    IATA_CODES: '/cors/http://www.ryanair.com/en/api/2/forms/flight-booking-selector/',
-    CHEAP_FLIGHTS: '/cors/http://www.ryanair.com/en/api/2/flights/'
+    AIRPORTS: '/cors/https://ryanair-test.herokuapp.com/api/airports',
+    IATA_CODES: '/cors/https://www.ryanair.com/en/api/2/forms/flight-booking-selector/',
+    CHEAP_FLIGHTS: '/cors/https://www.ryanair.com/en/api/2/flights/'
   })
   /**
    * Main App Controller

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 var express = require('express'),
     app     = express(),
-    http    = require('http'),
+    https   = require('https'),
     url     = require('url');
 
 app.use(express.static('public'));
@@ -12,7 +12,7 @@ app.get('/cors/*', function(request, response) {
   var options = url.parse(request.url),
       path = options.path.replace(/\/cors\//, '');
 
-  var connector = http.get(path, function(res) {
+  var connector = https.get(path, function(res) {
     response.setHeader('Content-Type', 'application/json');
     res.pipe(response, { end: true });
   });


### PR DESCRIPTION
Closes #1 

`http` module does not handle https requests, moved to `https`.
